### PR TITLE
add taxable income in usd and fx functionality; fix pls_wallet_history database logging only when difference between current and previous

### DIFF
--- a/app/rskcore/models.py
+++ b/app/rskcore/models.py
@@ -387,25 +387,37 @@ class pls_wallet_history(db.Model):
     address = db.Column('address', db.String(100), db.ForeignKey('pls_wallets.address'), nullable = False)
     balance = db.Column('balance', db.Float, nullable = False)
     date = db.Column('date', db.DateTime, nullable = False)
+    priceUSD = db.Column('priceUSD', db.Float, nullable = False)
+    priceFX = db.Column('priceFX', db.Float, nullable = False)
+    taxableIncomeUSD = db.Column('taxableIncomeUSD', db.Float, nullable = False)
+    taxableIncomeFX = db.Column('taxableIncomeFX', db.Float, nullable = False)
     
-    def __init__(self, address, balance, date):
+    def __init__(self, address, balance, date, priceUSD, priceFX, taxableIncomeUSD, taxableIncomeFX):
         self.address = address
         self.balance = balance
         self.date = date
+        self.priceUSD = priceUSD
+        self.priceFX = priceFX
+        self.taxableIncomeUSD = taxableIncomeUSD
+        self.taxableIncomeFX = taxableIncomeFX
     
     def __repr__(self):
-        return f'{self.address} - {self.balance} - {self.date}'
+        return f'{self.address} - {self.balance} - {self.date} - {self.priceUSD} - {self.priceFX} - {self.taxableIncomeUSD}- {self.taxableIncomeFX}'
     
     @staticmethod
     def get_all():
         return pls_wallet_history.query.all()
     
     @staticmethod
-    def new_balance(address, balance):
+    def new_balance(address, balance, price_usd, price_fx, taxableIncome_usd, taxableIncome_fx):
         my_balance = pls_wallet_history(
             address = address,
             balance = balance,
             date = datetime.now(),
+            priceUSD = price_usd,
+            priceFX = price_fx,
+            taxableIncomeUSD = taxableIncome_usd,
+            taxableIncomeFX = taxableIncome_fx
         )
         db.session.add(my_balance)
         db.session.commit()
@@ -418,21 +430,23 @@ class pls_price(db.Model):
     id = db.Column('id', db.Integer, primary_key = True)
     date = db.Column('date', db.DateTime, nullable = False)
     priceUSD = db.Column('priceUSD', db.Float, nullable = False)
+    priceFX = db.Column('priceFX', db.Float, nullable = False)
     
-    def __init__(self, date, priceUSD):
+    def __init__(self, date, priceUSD, priceFX):
         self.date = date
         self.priceUSD = priceUSD
+        self.priceFX = priceFX
         
     def __repr__(self):
-        return f'{self.date} - {self.priceUSD}'
+        return f'{self.date} - {self.priceUSD} - {self.priceFX}'
     
     @staticmethod
     def get_last():
         return pls_price.query.order_by(pls_price.date.desc()).first()
     
     @staticmethod
-    def store_new_price(value):
-        new_price = pls_price(datetime.now(), value)
+    def store_new_price(valueUSD, valueFX):
+        new_price = pls_price(datetime.now(), valueUSD, valueFX)
         db.session.add(new_price)
         db.session.commit()
     
@@ -477,8 +491,9 @@ class pls_validator_withdrawals(db.Model):
     amount = db.Column('amount', db.Float, nullable = False)
     timeStamp = db.Column('timeStamp', db.DateTime, nullable = False)
     priceUSD = db.Column('priceUSD', db.Float, nullable = True)
+    priceFX = db.Column('priceFX', db.Float, nullable = False)
     
-    def __init__(self, index, validatorIndex, blockNumber, address, miner, amount, timeStamp, priceUSD):
+    def __init__(self, index, validatorIndex, blockNumber, address, miner, amount, timeStamp, priceUSD, priceFX):
         self.index = index
         self.validatorIndex = validatorIndex
         self.blockNumber = blockNumber
@@ -487,9 +502,10 @@ class pls_validator_withdrawals(db.Model):
         self.amount = amount
         self.timeStamp = timeStamp
         self.priceUSD = priceUSD
+        self.priceFX = priceFX
         
     def __repr__(self):
-        return f'{self.index} - {self.validatorIndex} - {self.blockNumber} - {self.address} - {self.miner} - {self.amount} - {self.timeStamp} - {self.priceUSD}'
+        return f'{self.index} - {self.validatorIndex} - {self.blockNumber} - {self.address} - {self.miner} - {self.amount} - {self.timeStamp} - {self.priceUSD} -{self.priceFX}'
     
     @staticmethod
     def get_all():

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -116,10 +116,6 @@ def wallets_review():
                 #print(f'{balance_diff}')
                 if float(current_balance) != previous_balance:
                     if float(current_balance) > previous_balance:
-<<<<<<< HEAD
-                        taxableIncome_USD = (float(current_balance) - previous_balance) * price_usd
-                        taxableIncome_FX = (float(current_balance) - previous_balance) * price_fx
-=======
                         balance_increase = float(current_balance) - previous_balance
                         if balance_increase < 32000000:
                             #increase in balance from validator rewards and/or fee recipient tips/rewards
@@ -130,7 +126,6 @@ def wallets_review():
                             #rewards and/or fee recipient tips/rewards
                             taxableIncome_USD = (balance_increase - (balance_increase//32000000 * 32000000)) * price_usd
                             taxableIncome_FX = (balance_increase - (balance_increase//32000000 * 32000000)) * price_fx
->>>>>>> 9cacddf6538d3f51f2690b3d5b10021be1080f55
                     else:
                         taxableIncome_USD = 0
                         taxableIncome_FX = 0

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -110,10 +110,6 @@ def wallets_review():
                 # save new value for history purposes
                 current_balance = wallet_info['result']
                 previous_balance = pls_wallets.get_balance(wallet.address)
-                #balance_diff = float(current_balance) - previous_balance
-                #prGreen(f'{current_balance}')
-                #prGreen(f'{previous_balance}')
-                #print(f'{balance_diff}')
                 if float(current_balance) != previous_balance:
                     if float(current_balance) > previous_balance:
                         balance_increase = float(current_balance) - previous_balance
@@ -124,8 +120,8 @@ def wallets_review():
                         else:
                             #increase in balance caused by exiting validator/s with or without validator
                             #rewards and/or fee recipient tips/rewards
-                            taxableIncome_USD = (balance_increase - (balance_increase//32000000 * 32000000)) * price_usd
-                            taxableIncome_FX = (balance_increase - (balance_increase//32000000 * 32000000)) * price_fx
+                            taxableIncome_USD = (balance_increase % 32000000) * price_usd
+                            taxableIncome_FX = (balance_increase % 32000000) * price_fx
                     else:
                         taxableIncome_USD = 0
                         taxableIncome_FX = 0

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -116,8 +116,16 @@ def wallets_review():
                 #print(f'{balance_diff}')
                 if float(current_balance) != previous_balance:
                     if float(current_balance) > previous_balance:
-                        taxableIncome_USD = (float(current_balance) - previous_balance) * price_usd
-                        taxableIncome_FX = (float(current_balance) - previous_balance) * price_fx
+                        balance_increase = float(current_balance) - previous_balance
+                        if balance_increase < 32000000:
+                            #increase in balance from validator rewards and/or fee recipient tips/rewards
+                            taxableIncome_USD = balance_increase * price_usd
+                            taxableIncome_FX = balance_increase * price_fx
+                        else:
+                            #increase in balance caused by exiting validator/s with or without validator
+                            #rewards and/or fee recipient tips/rewards
+                            taxableIncome_USD = (balance_increase - (balance_increase//32000000 * 32000000)) * price_usd
+                            taxableIncome_FX = (balance_increase - (balance_increase//32000000 * 32000000)) * price_fx
                     else:
                         taxableIncome_USD = 0
                         taxableIncome_FX = 0

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -34,25 +34,34 @@ from app.rskcore.models import pls_wallets, \
 REWARD_BASE_PCT = app.config['REWARD_BASE_PCT']
 PLS_PRICE_URI = app.config['PLS_PRICE_URI']
 PLS_PRICE_API_KEY = app.config['PLS_PRICE_API_KEY']
+PLS_PRICE_FX = app.config['PLS_PRICE_FX']
+
 
 # get price from provider
-def get_price(uri, api_key):
+def get_price(uri, api_key, fx_param):
     headers = {'X-CMC_PRO_API_KEY': api_key}
+    #parameters = {'convert': 'AUD'}
+    parameters = {'convert': fx_param}
     try:
-        response = requests.get(uri, headers=headers)
-        data = json.loads(response.text)
+        response1 = requests.get(uri, headers=headers)
+        response2 = requests.get(uri, headers=headers, params=parameters)
+        data1 = json.loads(response1.text)
+        data2 = json.loads(response2.text)
     except Exception as e:
         log2store = f"{get_time()} | Error getting data from price API: {str(e)}"
         prRed(f'{get_time()} | {log2store}')
         price_usd = pls_price.get_last().priceUSD
-        return price_usd
+        price_fx = pls_price.get_last().priceFX
+        return price_usd, price_fx
     try:
-        price_usd = float(data['data']['11145']['quote']['USD']['price'])
+        price_usd = float(data1['data']['11145']['quote']['USD']['price'])
+        price_fx = float(data2['data']['11145']['quote'][fx_param]['price'])
     except Exception as e:
         log2store = f"{get_time()} | Error getting price from API: {str(e)}"
         prRed(f'{get_time()} | {log2store}')
         price_usd = pls_price.get_last().priceUSD
-    return price_usd
+        price_fx = pls_price.get_last().priceFX
+    return price_usd, price_fx
 
 # ###############################################################################
 # setting up tasks
@@ -66,7 +75,7 @@ def pls_price_update():
     new_log(users_id=1, module='PRICE_UPDATE', severity=SEV_INF, description=log2store, data=log2store, image=None)
     # get PLS price
     try:
-        price_usd = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY)
+        price_usd, price_fx = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY, PLS_PRICE_FX)
     except Exception as e:
         log2store = f"{get_time()} | Error getting data from price API: {str(e)}"
         prRed(f'{get_time()} | {log2store}')
@@ -75,7 +84,7 @@ def pls_price_update():
     if everything_ok:
         # store price in db
         try:
-            pls_price.store_new_price(price_usd)
+            pls_price.store_new_price(price_usd, price_fx)
         except Exception as e:
             log2store = f"{get_time()} | Error storing price in db: {str(e)}"
             prRed(f'{get_time()} | SCHEDULER ==> {log2store}')
@@ -91,6 +100,7 @@ def wallets_review():
     new_log(users_id=1, module='PLS_WALLET', severity=SEV_INF, description=log2store, data=log2store, image=None)
     # get all wallets
     pls_wallets_list = pls_wallets.query.all()
+    price_usd, price_fx = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY, PLS_PRICE_FX)
     for wallet in pls_wallets_list:
         wallet_data_uri = f'https://scan.pulsechain.com/api?module=account&action=balance&address={wallet.address}'
         wallet_data = requests.get(wallet_data_uri)
@@ -100,8 +110,18 @@ def wallets_review():
                 # save new value for history purposes
                 current_balance = wallet_info['result']
                 previous_balance = pls_wallets.get_balance(wallet.address)
-                if current_balance != previous_balance:
-                    pls_wallet_history.new_balance(wallet.address, current_balance)
+                #balance_diff = float(current_balance) - previous_balance
+                #prGreen(f'{current_balance}')
+                #prGreen(f'{previous_balance}')
+                #print(f'{balance_diff}')
+                if float(current_balance) != previous_balance:
+                    if float(current_balance) > previous_balance:
+                        taxableIncome_USD = (float(current_balance) - previous_balance) * price_usd
+                        taxableIncome_FX = (float(current_balance) - previous_balance) * price_fx
+                    else:
+                        taxableIncome_USD = 0
+                        taxableIncome_FX = 0
+                    pls_wallet_history.new_balance(wallet.address, current_balance, price_usd, price_fx, taxableIncome_USD, taxableIncome_FX)
                     # update wallet balance
                     pls_wallets.update_balance(wallet.address, current_balance)
                     log2store = f'Wallet {wallet.address} updated with balance {current_balance}'
@@ -127,9 +147,9 @@ def validator_update():
     block_current = web3.eth.get_block_number()
     block_last_managed = pls_block_explorer.get_last()
     block_last_height = app.config['MAX_HEIGHT_CHECK'] if block_last_managed is None else block_last_managed.blockheight
-    # get pls current price, we don't need to much precision, it's good enough to get this price on this run for all withdrawals found
+    # get pls current price, we don't need too much precision, it's good enough to get this price on this run for all withdrawals found
     # and also is good to no stress and overload the API
-    price_usd = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY)
+    price_usd, price_fx = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY, PLS_PRICE_FX)
     # get wallets
     wallets = pls_wallets.get_all()
     for wallet in wallets:
@@ -155,7 +175,8 @@ def validator_update():
                             w_miner = block_data.miner
                             w_timestamp = datetime.datetime.fromtimestamp(int(block_data.timestamp))
                             w_address = wallet.address
-                            w_price = price_usd
+                            w_price_usd = price_usd
+                            w_price_fx = price_fx
                             new_withdrawal_data = pls_validator_withdrawals(
                                 index = w_index,
                                 validatorIndex = w_validatorIndex,
@@ -164,7 +185,8 @@ def validator_update():
                                 miner = w_miner,
                                 timeStamp = w_timestamp,
                                 address = w_address,
-                                priceUSD = w_price
+                                priceUSD = w_price_usd,
+                                priceFX = w_price_fx
                             )
                             db.session.add(new_withdrawal_data)
                             try:
@@ -194,9 +216,9 @@ def validator_update():
 def pls_custom_sync(xfrom, xto):
     # fire up web3
     web3 = Web3(Web3.HTTPProvider(app.config['WEB3_PROVIDER_URI']))
-    # get pls current price, we don't need to much precision, it's good enough to get this price on this run for all withdrawals found
+    # get pls current price, we don't need too much precision, it's good enough to get this price on this run for all withdrawals found
     # and also is good to no stress and overload the API
-    price_usd = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY)
+    price_usd, price_fx = get_price(PLS_PRICE_URI, PLS_PRICE_API_KEY, PLS_PRICE_FX)
     # get wallets    
     wallets = pls_wallets.get_all()    
     for wallet in wallets:
@@ -219,7 +241,8 @@ def pls_custom_sync(xfrom, xto):
                         w_miner = block_data.miner
                         w_timestamp = datetime.datetime.fromtimestamp(int(block_data.timestamp))
                         w_address = wallet.address
-                        w_price = price_usd
+                        w_price_usd = price_usd
+                        w_price_fx = price_fx
                         new_withdrawal_data = pls_validator_withdrawals(
                             index = w_index,
                             validatorIndex = w_validatorIndex,
@@ -228,7 +251,8 @@ def pls_custom_sync(xfrom, xto):
                             miner = w_miner,
                             timeStamp = w_timestamp,
                             address = w_address,
-                            priceUSD = w_price
+                            priceUSD = w_price_usd,
+                            priceFX = w_price_fx
                         )
                         db.session.add(new_withdrawal_data)
                         try:
@@ -248,6 +272,6 @@ def pls_custom_sync(xfrom, xto):
 # ###############################################################################
 
 schedule.every(10).minutes.do(pls_price_update)
-schedule.every(15).minutes.do(wallets_review)
+schedule.every(6).minutes.do(wallets_review)
 schedule.every().hour.at(":15").do(validator_update)
 schedule.every().hour.at(":45").do(validator_update)


### PR DESCRIPTION
I saw an opportunity to address an issue that I see with being able to easily calculate the taxable income obligation for validator rewards, not just from attesting/sync committee duties, but also from fee recipient amounts received by validators.

Even for just one validator, the number of withdrawals is not insignificant and knowing the value of each of those transactions at the time that the validator operator gains dominion over those rewards/fees with the current pulsechain block explorer is not easily determined. It requires the validator operator to reconcile the value of the rewards/fees by cross referencing the date/time of the transaction against the PLS token USD and FX currency values. This is no small task and would be extremely laborious to do after the fact.

The changes I made calculate the taxable income obligation in both USD and the FX currency of your choosing at, or very close to, the time that the rewards/fees are received into the wallet that was configured to receive these rewards/fees at the time the validator was set up.

Every 6 minutes (or at a time interval of your choosing), the PLS balance is read from the user's wallet address and compared to the previous balance value. If it is positive, then the balance has increased due to either validator rewards OR fee recipient amounts (priority tips). The difference between the current and previous balance is then multiplied by the USD price & the FX price of PLS (that were queried and retrieved from CMC at the same iteration of the code) to determine the value of the income received, which in many countries is considered taxable income. It is then stored in the database and this value can then be displayed in Grafana as a running summed total. I have built this Grafana display by simply adding a new panel with an underlying SELECT SUM query.

This requires the addition of an additional variable called PLS_PRICE_FX to the config/prod.py file.

It also assumes (and requires) that the wallet, specified by the user using the web front end, receives PLS income from validator activities only.